### PR TITLE
Add license text and license header re issue #1

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,17 @@
+_The new code here was written by hassansin, and is licensed under the
+Internet Software Consortium (ISC) License, the text of which is given
+below._
+
+Copyright (c) 2014-2015, hassansin
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/address.js
+++ b/address.js
@@ -1,3 +1,5 @@
+// Copyright (c) 2014-2015, hassansin
+//
 //Perl Ref: http://cpansearch.perl.org/src/TIMB/Geo-StreetAddress-US-1.04/US.pm
 "use strict";
 


### PR DESCRIPTION
Add the text of the ISC license and a header to address.js.  I mentioned
@hassansin by GitHub username in the copyright notice, but they may wish
to use their real name.