### PR TITLE
added Zip4 tests

### DIFF
--- a/test.js
+++ b/test.js
@@ -299,6 +299,33 @@ var address = {
     zip: '60606',
     plus4: '6306'
   },
+  // this test passes
+   "60606-6306": {
+     zip: "60606",
+     plus4: "6306"
+   },
+   // non-hyphenated zip4 is incorrectly associated to street address
+   "60606 6306": {
+     zip: "60606",
+     plus4: "6306"
+   },
+   // same non-hyphenated zip4 pattern but with street address, correctly identifies street address but doesn't pick up zip4
+   "233 S Wacker Dr 60606 6306": {
+     number: "233",
+     prefix: "S",
+     street: "Wacker",
+     type: "Dr",
+     zip: "60606",
+     plus4: "6306"
+   },
+   // likely just the samed underlying problem with non-hypenated syntax
+   "S Wacker Dr 60606 6306": {
+     prefix: "S",
+     street: "Wacker",
+     type: "Dr",
+     zip: "60606",
+     plus4: "6306"
+   },
   '233 S Wacker Dr lobby 60606': {
     number: '233',
     prefix: 'S',


### PR DESCRIPTION
All of the test cases you had setup seem to work as expected but there are some other patterns I'm expecting from users so I added some more tests to represent them. In general there seems to still be an issue with distinguishing a non dasherized/hyphenated representation of Zip5+4 (aka, 90291 3606)