### PR TITLE
Implement Geo::StreetAddress::US's normalizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## US Street Address Parser  [![Build Status](https://travis-ci.org/hassansin/parse-address.svg)](https://travis-ci.org/hassansin/parse-address)
+# US Street Address Parser  [![Build Status](https://travis-ci.org/hassansin/parse-address.svg)](https://travis-ci.org/hassansin/parse-address)
 
 This is Node.js port for Perl [Geo::StreetAddress::US](http://search.cpan.org/~timb/Geo-StreetAddress-US-1.04/US.pm) package
 
@@ -6,7 +6,7 @@ This is Node.js port for Perl [Geo::StreetAddress::US](http://search.cpan.org/~t
 
 >Geo::StreetAddress::US is a regex-based street address and street intersection parser for the United States. Its basic goal is to be as forgiving as possible when parsing user-provided address strings. Geo::StreetAddress::US knows about directional prefixes and suffixes, fractional building numbers, building units, grid-based addresses (such as those used in parts of Utah), 5 and 9 digit ZIP codes, and all of the official USPS abbreviations for street types and state names... [more](http://search.cpan.org/~timb/Geo-StreetAddress-US-1.04/US.pm)
 
-### Usage:
+## Usage:
 
 ```javascript
 //from node:
@@ -19,14 +19,12 @@ var parsed = parser.parseLocation('1005 N Gravenstein Highway Sebastopol CA 9547
 var parsed = parseAddress.parseLocation('1005 N Gravenstein Highway Sebastopol CA 95472');
 
 //Parsed address:
-{ 
+{
  number: '1005',
  prefix: 'N',
  street: 'Gravenstein',
- type: 'Highway',
+ type: 'Hwy',
  city: 'Sebastopol',
  state: 'CA',
  zip: '95472' }
- 
 ```
- 

--- a/address.js
+++ b/address.js
@@ -460,6 +460,19 @@
   var Direction_Code;
   var initialized = false;
 
+  var Normalize_Map = {
+    prefix: Directional,
+    prefix1: Directional,
+    prefix2: Directional,
+    suffix: Directional,
+    suffix1: Directional,
+    suffix2: Directional,
+    type: Street_Type,
+    type1: Street_Type,
+    type2: Street_Type,
+    state: State_Code,
+  }
+
   function capitalize(s){
     return s && s[0].toUpperCase() + s.slice(1);
   }
@@ -636,14 +649,25 @@
       if(parts[k])
         parsed[key] = parts[k].trim().replace(/[^\w\s\-\#\&]/,'');
     });
+    each(Normalize_Map, function(map,key) {
+      if(parsed[key] && map[parsed[key].toLowerCase()]) {
+        parsed[key] = map[parsed[key].toLowerCase()];
+      }
+    });
+
+    ['type', 'type1', 'type2'].forEach(function(key){
+      if(key in parsed)
+        parsed[key] = parsed[key].charAt(0).toUpperCase() + parsed[key].slice(1).toLowerCase()
+    });
+
     if (this.avoid_redundant_street_type) {
       ['', '1', '2'].forEach(function (suffix) {
-          if(!parsed['street'+suffix]) return
-          if(!parsed['type'+suffix]) return
-          const type = parsed['type'+suffix]
-          const type_regex = Street_Type_Match[type.toLowerCase()]
-          if(!type_regex) return // Perl calls die here. Should we?
-          parsed['type'+suffix] =  || type.toLowerCase()
+          if(!parsed['street'+suffix]) return;
+          if(!parsed['type'+suffix]) return;
+          const type = parsed['type'+suffix];
+          const type_regex = Street_Type_Match[type.toLowerCase()];
+          if(!type_regex) return; // Perl calls die here. Should we?
+          if(type_regex.match(parsed['street'+suffix])) parsed['type'+suffix] = undefined;
       })
     }
     if(parsed.city){

--- a/address.js
+++ b/address.js
@@ -16,7 +16,6 @@
 
   var parser = {};
   var Addr_Match = {};
-  var Street_Type_Match = {};
 
   var Directional = {
     north       : "N",
@@ -509,12 +508,12 @@
 
     Direction_Code = invert(Directional);
 
-
+    /*
     var Street_Type_Match = {};
     each(Street_Type,function(v,k){ Street_Type_Match[v] = XRegExp.escape(v) });
     each(Street_Type,function(v,k){ Street_Type_Match[v] = Street_Type_Match[v] + "|" + XRegExp.escape(k); });
     each(Street_Type_Match,function(v,k){ Street_Type_Match[k] = new RegExp( '\\b(?:' +  Street_Type_Match[k]  + ')\\b', 'i') });
-
+    */
 
     Addr_Match = {
       type    : flatten(Street_Type).sort().filter(function(v,i,arr){return arr.indexOf(v)===i }).join('|'),

--- a/address.js
+++ b/address.js
@@ -645,7 +645,7 @@
         return;
       var key = isFinite(k.split('_').pop())? k.split('_').slice(0,-1).join('_'): k ;
       if(parts[k])
-        parsed[key] = parts[k].trim().replace(/^\s+|\s+$|[^\w\s\-#&]/gs, '');
+        parsed[key] = parts[k].trim().replace(/^\s+|\s+$|[^\w\s\-#&]/g, '');
     });
     each(Normalize_Map, function(map,key) {
       if(parsed[key] && map[parsed[key].toLowerCase()]) {

--- a/address.js
+++ b/address.js
@@ -666,8 +666,8 @@
           if(!parsed['type'+suffix]) return;
           const type = parsed['type'+suffix];
           const type_regex = Street_Type_Match[type.toLowerCase()];
-          if(!type_regex) return; // Perl calls die here. Should we?
-          if(type_regex.match(parsed['street'+suffix])) parsed['type'+suffix] = undefined;
+          if(!type_regex) return;
+          if(type_regex.match(parsed['street'+suffix])) delete parsed['type'+suffix];
       })
     }
     if(parsed.city){

--- a/address.js
+++ b/address.js
@@ -647,7 +647,7 @@
         return;
       var key = isFinite(k.split('_').pop())? k.split('_').slice(0,-1).join('_'): k ;
       if(parts[k])
-        parsed[key] = parts[k].trim().replace(/[^\w\s\-\#\&]/,'');
+        parsed[key] = parts[k].trim().replace(/^\s+|\s+$|[^\w\s\-#&]/gs, '');
     });
     each(Normalize_Map, function(map,key) {
       if(parsed[key] && map[parsed[key].toLowerCase()]) {

--- a/address.js
+++ b/address.js
@@ -655,7 +655,7 @@
 
     ['type', 'type1', 'type2'].forEach(function(key){
       if(key in parsed)
-        parsed[key] = parsed[key].charAt(0).toUpperCase() + parsed[key].slice(1).toLowerCase()
+        parsed[key] = parsed[key].charAt(0).toUpperCase() + parsed[key].slice(1).toLowerCase();
     });
 
     if(parsed.city){

--- a/address.js
+++ b/address.js
@@ -635,7 +635,6 @@
       '+Addr_Match.street.replace(/_\d/g,'2$&') + '\\W+     \n\
       '+Addr_Match.place+'\\W*$','ix');
   }
-  parser.avoid_redundant_street_type = true
   parser.normalize_address = function(parts){
     lazyInit();
     if(!parts)
@@ -660,16 +659,6 @@
         parsed[key] = parsed[key].charAt(0).toUpperCase() + parsed[key].slice(1).toLowerCase()
     });
 
-    if (this.avoid_redundant_street_type) {
-      ['', '1', '2'].forEach(function (suffix) {
-          if(!parsed['street'+suffix]) return;
-          if(!parsed['type'+suffix]) return;
-          const type = parsed['type'+suffix];
-          const type_regex = Street_Type_Match[type.toLowerCase()];
-          if(!type_regex) return;
-          if(type_regex.match(parsed['street'+suffix])) delete parsed['type'+suffix];
-      })
-    }
     if(parsed.city){
       parsed.city = XRegExp.replace(parsed.city,
         XRegExp('^(?<dircode>'+Addr_Match.dircode+')\\s+(?=\\S)','ix'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "parse-address",
+  "version": "0.0.10",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "xregexp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-3.2.0.tgz",
+      "integrity": "sha1-yzYBmHv+JpW1hAAMGPHEqMMih44="
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-address",
-  "version": "0.0.10",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-address",
-  "version": "0.0.10",
+  "version": "1.0.0",
   "description": "US Street Address Parser",
   "main": "address.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -113,7 +113,6 @@ var address = {
   },
   '115 Broadway San Francisco CA': {
     street: 'Broadway',
-    type: '',
     city: 'San Francisco',
     state: 'CA',
     number: '115'
@@ -135,7 +134,6 @@ var address = {
     street: 'Mill Station'
   },
   '1005 State Highway 116 Sebastopol CA 95472': {
-    type: 'Hwy',
     city: 'Sebastopol',
     zip: '95472',
     state: 'CA',
@@ -162,12 +160,10 @@ var address = {
     city: 'Salt Lake City',
     number: '48',
     state: 'UT',
-    suffix: 'E',
-    type: ''
+    suffix: 'E'
   },
   '550 S 400 E #3206, Salt Lake City UT 84111': {
     suffix: 'E',
-    type: '',
     number: '550',
     sec_unit_num: '3206',
     prefix: 'S',
@@ -181,7 +177,6 @@ var address = {
     city: 'Park City',
     sec_unit_num: 'D304',
     prefix: 'N',
-    type: '',
     number: '6641',
     sec_unit_type: 'Apt',
     state: 'UT',
@@ -201,7 +196,7 @@ var address = {
     type: 'Ave',
     state: 'MN',
     street: 'Washington',
-    prefix: 'SE',
+    prefix: 'SE.',
     number: '100'
   },
   '3813 1/2 Some Road, Los Angeles, CA': {
@@ -286,35 +281,38 @@ var address = {
     city: 'Rochester',
     street: 'Maple',
     number: '123',
-    state: 'NY',
-    type: ''
+    state: 'NY'
   },
   '233 S Wacker Dr 60606-6306': {
     type: 'Dr',
     number: '233',
     prefix: 'S',
     zip: '60606',
-    street: 'Wacker'
+    street: 'Wacker',
+    plus4: '6306'
   },
   '233 S Wacker Dr 606066306': {
     street: 'Wacker',
     zip: '60606',
     type: 'Dr',
     number: '233',
-    prefix: 'S'
+    prefix: 'S',
+    plus4: '6306'
   },
   '233 S Wacker Dr 60606 6306': {
     type: 'Dr',
     prefix: 'S',
     zip: '60606',
     street: 'Wacker',
-    number: '233'
+    number: '233',
+    plus4: '6306'
   },
   'S Wacker Dr 60606 6306': {
     zip: '60606',
     type: 'Dr',
     street: 'Wacker',
-    prefix: 'S'
+    prefix: 'S',
+    plus4: '6306'
   },
   '233 S Wacker Dr lobby 60606': {
     sec_unit_type: 'lobby',
@@ -351,7 +349,6 @@ var address = {
     sec_unit_num: '42'
   },
   '36401 County Road 43, Eaton, CO 80615': {
-    type: 'Rd',
     street: 'County Road 43',
     number: '36401',
     zip: '80615',
@@ -361,7 +358,6 @@ var address = {
   '1234 COUNTY HWY 60E, Town, CO 12345': {
     suffix: 'E',
     state: 'CO',
-    type: '',
     zip: '12345',
     number: '1234',
     city: 'Town',
@@ -370,7 +366,6 @@ var address = {
   '321 S. Washington': {
     prefix: 'S',
     street: 'Washington',
-    type: '',
     number: '321'
   },
   '\'45 Quaker Ave, Ste 105\'': {
@@ -382,10 +377,10 @@ var address = {
   },
   '2672 Industrial Row Troy, MI 48084': {
     zip: '48084',
-    city: 'Row Troy',
+    type: 'Row',
+    city: 'Troy',
     number: '2672',
     state: 'MI',
-    type: '',
     street: 'Industrial'
   }
 };

--- a/test.js
+++ b/test.js
@@ -196,7 +196,7 @@ var address = {
     type: 'Ave',
     state: 'MN',
     street: 'Washington',
-    prefix: 'SE.',
+    prefix: 'SE',
     number: '100'
   },
   '3813 1/2 Some Road, Los Angeles, CA': {

--- a/test.js
+++ b/test.js
@@ -37,355 +37,356 @@ var address = {
     state: 'CA'
   },
   '1005 N Gravenstein Highway, Suite 500, Sebastopol, CA': {
-    type: 'Hwy',
-    street: 'Gravenstein',
-    city: 'Sebastopol',
-    state: 'CA',
+    number: '1005',
     prefix: 'N',
-    sec_unit_num: '500',
+    street: 'Gravenstein',
+    type: 'Hwy',
     sec_unit_type: 'Suite',
-    number: '1005'
+    sec_unit_num: '500',
+    city: 'Sebastopol',
+    state: 'CA'
   },
   '1005 N Gravenstein Hwy Suite 500 Sebastopol, CA': {
     number: '1005',
-    type: 'Hwy',
-    city: 'Sebastopol',
-    state: 'CA',
-    sec_unit_type: 'Suite',
-    street: 'Gravenstein',
     prefix: 'N',
-    sec_unit_num: '500'
+    street: 'Gravenstein',
+    type: 'Hwy',
+    sec_unit_type: 'Suite',
+    sec_unit_num: '500',
+    city: 'Sebastopol',
+    state: 'CA'
   },
   '1005 N Gravenstein Highway, Sebastopol, CA, 95472': {
-    state: 'CA',
     number: '1005',
-    zip: '95472',
     prefix: 'N',
-    city: 'Sebastopol',
     street: 'Gravenstein',
-    type: 'Hwy'
+    type: 'Hwy',
+    city: 'Sebastopol',
+    state: 'CA',
+    zip: '95472'
   },
   '1005 N Gravenstein Highway Sebastopol CA 95472': {
-    street: 'Gravenstein',
-    zip: '95472',
-    prefix: 'N',
-    state: 'CA',
     number: '1005',
+    prefix: 'N',
+    street: 'Gravenstein',
+    type: 'Hwy',
     city: 'Sebastopol',
-    type: 'Hwy'
+    state: 'CA',
+    zip: '95472'
   },
   '1005 Gravenstein Hwy N Sebastopol CA': {
-    street: 'Gravenstein',
-    state: 'CA',
-    city: 'Sebastopol',
-    suffix: 'N',
     number: '1005',
-    type: 'Hwy'
+    street: 'Gravenstein',
+    type: 'Hwy',
+    suffix: 'N',
+    city: 'Sebastopol',
+    state: 'CA'
   },
   '1005 Gravenstein Hwy N, Sebastopol CA': {
-    type: 'Hwy',
     number: '1005',
+    street: 'Gravenstein',
+    type: 'Hwy',
     suffix: 'N',
     city: 'Sebastopol',
-    street: 'Gravenstein',
     state: 'CA'
   },
   '1005 Gravenstein Hwy, N Sebastopol CA': {
-    street: 'Gravenstein',
     number: '1005',
-    state: 'CA',
+    street: 'Gravenstein',
+    type: 'Hwy',
     city: 'North Sebastopol',
-    type: 'Hwy'
+    state: 'CA'
   },
   '1005 Gravenstein Hwy, North Sebastopol CA': {
-    type: 'Hwy',
-    street: 'Gravenstein',
-    state: 'CA',
     number: '1005',
-    city: 'North Sebastopol'
+    street: 'Gravenstein',
+    type: 'Hwy',
+    city: 'North Sebastopol',
+    state: 'CA'
   },
   '1005 Gravenstein Hwy Sebastopol CA': {
     number: '1005',
+    street: 'Gravenstein',
     type: 'Hwy',
     city: 'Sebastopol',
-    state: 'CA',
-    street: 'Gravenstein'
+    state: 'CA'
   },
   '115 Broadway San Francisco CA': {
+    number: '115',
     street: 'Broadway',
     city: 'San Francisco',
-    state: 'CA',
-    number: '115'
+    state: 'CA'
   },
   '7800 Mill Station Rd, Sebastopol, CA 95472': {
-    state: 'CA',
-    type: 'Rd',
+    number: '7800',
     street: 'Mill Station',
-    zip: '95472',
+    type: 'Rd',
     city: 'Sebastopol',
-    number: '7800'
+    state: 'CA',
+    zip: '95472'
   },
   '7800 Mill Station Rd Sebastopol CA 95472': {
     number: '7800',
-    city: 'Sebastopol',
-    zip: '95472',
-    state: 'CA',
+    street: 'Mill Station',
     type: 'Rd',
-    street: 'Mill Station'
+    city: 'Sebastopol',
+    state: 'CA',
+    zip: '95472'
   },
   '1005 State Highway 116 Sebastopol CA 95472': {
-    city: 'Sebastopol',
-    zip: '95472',
-    state: 'CA',
+    number: '1005',
     street: 'State Highway 116',
-    number: '1005'
+    city: 'Sebastopol',
+    state: 'CA',
+    zip: '95472'
   },
   '1600 Pennsylvania Ave. Washington DC': {
-    state: 'DC',
+    number: '1600',
     street: 'Pennsylvania',
     type: 'Ave',
-    number: '1600',
-    city: 'Washington'
+    city: 'Washington',
+    state: 'DC'
   },
   '1600 Pennsylvania Avenue Washington DC': {
     number: '1600',
     street: 'Pennsylvania',
-    state: 'DC',
     type: 'Ave',
-    city: 'Washington'
+    city: 'Washington',
+    state: 'DC'
   },
   '48S 400E, Salt Lake City UT': {
+    number: '48',
     prefix: 'S',
     street: '400',
+    suffix: 'E',
     city: 'Salt Lake City',
-    number: '48',
-    state: 'UT',
-    suffix: 'E'
+    state: 'UT'
   },
   '550 S 400 E #3206, Salt Lake City UT 84111': {
-    suffix: 'E',
     number: '550',
-    sec_unit_num: '3206',
     prefix: 'S',
-    state: 'UT',
+    street: '400',
+    suffix: 'E',
     sec_unit_type: '#',
+    sec_unit_num: '3206',
     city: 'Salt Lake City',
-    zip: '84111',
-    street: '400'
+    state: 'UT',
+    zip: '84111'
   },
   '6641 N 2200 W Apt D304 Park City, UT 84098': {
-    city: 'Park City',
-    sec_unit_num: 'D304',
-    prefix: 'N',
     number: '6641',
-    sec_unit_type: 'Apt',
-    state: 'UT',
-    suffix: 'W',
+    prefix: 'N',
     street: '2200',
+    suffix: 'W',
+    sec_unit_type: 'Apt',
+    sec_unit_num: 'D304',
+    city: 'Park City',
+    state: 'UT',
     zip: '84098'
   },
   '100 South St, Philadelphia, PA': {
+    number: '100',
     street: 'South',
-    city: 'Philadelphia',
-    state: 'PA',
     type: 'St',
-    number: '100'
+    city: 'Philadelphia',
+    state: 'PA'
   },
   '100 S.E. Washington Ave, Minneapolis, MN': {
-    city: 'Minneapolis',
-    type: 'Ave',
-    state: 'MN',
-    street: 'Washington',
+    number: '100',
     prefix: 'SE',
-    number: '100'
+    street: 'Washington',
+    type: 'Ave',
+    city: 'Minneapolis',
+    state: 'MN'
   },
   '3813 1/2 Some Road, Los Angeles, CA': {
     number: '3813',
     street: 'Some',
     type: 'Rd',
-    state: 'CA',
-    city: 'Los Angeles'
+    city: 'Los Angeles',
+    state: 'CA'
   },
   'Mission & Valencia San Francisco CA': {
-    type2: '',
+    street1: 'Mission',
     street2: 'Valencia',
-    state: 'CA',
     city: 'San Francisco',
-    type1: '',
-    street1: 'Mission'
+    state: 'CA',
+    type2: '',
+    type1: ''
   },
   'Mission & Valencia, San Francisco CA': {
-    type1: '',
-    city: 'San Francisco',
-    type2: '',
     street1: 'Mission',
+    street2: 'Valencia',
+    city: 'San Francisco',
     state: 'CA',
-    street2: 'Valencia'
+    type2: '',
+    type1: ''
   },
   'Mission St and Valencia St San Francisco CA': {
+    street1: 'Mission',
     type1: 'St',
-    city: 'San Francisco',
-    state: 'CA',
     street2: 'Valencia',
     type2: 'St',
-    street1: 'Mission'
+    city: 'San Francisco',
+    state: 'CA'
   },
   'Mission St & Valencia St San Francisco CA': {
-    street2: 'Valencia',
-    state: 'CA',
-    street1: 'Mission',
-    type2: 'St',
-    city: 'San Francisco',
-    type1: 'St'
-  },
-  'Mission and Valencia Sts San Francisco CA': {
-    type2: 'St',
     street1: 'Mission',
     type1: 'St',
-    city: 'San Francisco',
     street2: 'Valencia',
+    type2: 'St',
+    city: 'San Francisco',
     state: 'CA'
+  },
+  'Mission and Valencia Sts San Francisco CA': {
+    street1: 'Mission',
+    street2: 'Valencia',
+    type2: 'St',
+    city: 'San Francisco',
+    state: 'CA',
+    type1: 'St'
   },
   'Mission & Valencia Sts. San Francisco CA': {
     street1: 'Mission',
     street2: 'Valencia',
-    type1: 'St',
+    type2: 'St',
     city: 'San Francisco',
     state: 'CA',
-    type2: 'St'
+    type1: 'St'
   },
   'Mission & Valencia Streets San Francisco CA': {
     street1: 'Mission',
+    street2: 'Valencia',
     type2: 'St',
     city: 'San Francisco',
     state: 'CA',
-    type1: 'St',
-    street2: 'Valencia'
+    type1: 'St'
   },
   'Mission Avenue and Valencia Street San Francisco CA': {
-    type1: 'Ave',
-    state: 'CA',
-    city: 'San Francisco',
     street1: 'Mission',
+    type1: 'Ave',
+    street2: 'Valencia',
     type2: 'St',
-    street2: 'Valencia'
+    city: 'San Francisco',
+    state: 'CA'
   },
   '1 First St, e San Jose CA': {
-    street: 'First',
     number: '1',
+    street: 'First',
+    type: 'St',
     city: 'East San Jose',
-    state: 'CA',
-    type: 'St'
+    state: 'CA'
   },
   '123 Maple Rochester, New York': {
-    city: 'Rochester',
-    street: 'Maple',
     number: '123',
+    street: 'Maple',
+    city: 'Rochester',
     state: 'NY'
   },
   '233 S Wacker Dr 60606-6306': {
-    type: 'Dr',
     number: '233',
     prefix: 'S',
-    zip: '60606',
     street: 'Wacker',
+    type: 'Dr',
+    zip: '60606',
     plus4: '6306'
   },
   '233 S Wacker Dr 606066306': {
-    street: 'Wacker',
-    zip: '60606',
-    type: 'Dr',
     number: '233',
     prefix: 'S',
+    street: 'Wacker',
+    type: 'Dr',
+    zip: '60606',
     plus4: '6306'
   },
   '233 S Wacker Dr 60606 6306': {
-    type: 'Dr',
-    prefix: 'S',
-    zip: '60606',
-    street: 'Wacker',
     number: '233',
+    prefix: 'S',
+    street: 'Wacker',
+    type: 'Dr',
+    zip: '60606',
     plus4: '6306'
   },
   'S Wacker Dr 60606 6306': {
-    zip: '60606',
-    type: 'Dr',
-    street: 'Wacker',
     prefix: 'S',
+    street: 'Wacker',
+    type: 'Dr',
+    zip: '60606',
     plus4: '6306'
   },
   '233 S Wacker Dr lobby 60606': {
-    sec_unit_type: 'lobby',
-    prefix: 'S',
-    type: 'Dr',
     number: '233',
+    prefix: 'S',
     street: 'Wacker',
+    type: 'Dr',
+    sec_unit_type: 'lobby',
     zip: '60606'
   },
   '(233 S Wacker Dr lobby 60606)': {
-    zip: '60606',
-    sec_unit_type: 'lobby',
+    number: '233',
+    prefix: 'S',
     street: 'Wacker',
     type: 'Dr',
-    number: '233',
-    prefix: 'S'
+    sec_unit_type: 'lobby',
+    zip: '60606'
   },
   '#42 233 S Wacker Dr 60606': {
-    type: 'Dr',
-    prefix: 'S',
-    zip: '60606',
-    sec_unit_num: '42',
     sec_unit_type: '#',
+    sec_unit_num: '42',
     number: '233',
-    street: 'Wacker'
+    prefix: 'S',
+    street: 'Wacker',
+    type: 'Dr',
+    zip: '60606'
   },
   'lt42 99 Some Road, Some City LA': {
-    city: 'Some City',
-    state: 'LA',
-    type: 'Rd',
     sec_unit_type: 'lt',
-    street: 'Some',
+    sec_unit_num: '42',
     number: '99',
-    sec_unit_num: '42'
+    street: 'Some',
+    type: 'Rd',
+    city: 'Some City',
+    state: 'LA'
   },
   '36401 County Road 43, Eaton, CO 80615': {
-    street: 'County Road 43',
     number: '36401',
-    zip: '80615',
+    street: 'County Road 43',
+    city: 'Eaton',
     state: 'CO',
-    city: 'Eaton'
+    zip: '80615'
   },
   '1234 COUNTY HWY 60E, Town, CO 12345': {
-    suffix: 'E',
-    state: 'CO',
-    zip: '12345',
     number: '1234',
+    street: 'COUNTY HWY 60',
+    suffix: 'E',
     city: 'Town',
-    street: 'COUNTY HWY 60'
+    state: 'CO',
+    zip: '12345'
   },
   '321 S. Washington': {
+    number: '321',
     prefix: 'S',
-    street: 'Washington',
-    number: '321'
+    street: 'Washington'
   },
   '\'45 Quaker Ave, Ste 105\'': {
-    sec_unit_type: 'Ste',
-    street: 'Quaker',
     number: '45',
+    street: 'Quaker',
     type: 'Ave',
+    sec_unit_type: 'Ste',
     sec_unit_num: '105'
   },
   '2672 Industrial Row Troy, MI 48084': {
-    zip: '48084',
+    number: '2672',
+    street: 'Industrial',
     type: 'Row',
     city: 'Troy',
-    number: '2672',
     state: 'MI',
-    street: 'Industrial'
+    zip: '48084'
   }
 };
 
 Object.keys(address).forEach(function (k) {
   var parsed = parser.parseLocation(k);
   assert.deepEqual(address[k], parsed);
+  console.log(JSON.stringify({[k]: parsed}))
 });

--- a/test.js
+++ b/test.js
@@ -24,368 +24,373 @@ var address = {
   '1005 Gravenstein Highway North, 95472': {
     number: '1005',
     street: 'Gravenstein',
-    type: 'Highway',
-    suffix: 'North',
+    type: 'Hwy',
+    suffix: 'N',
     zip: '95472'
   },
   '1005 N Gravenstein Highway, Sebastopol, CA': {
     number: '1005',
     prefix: 'N',
     street: 'Gravenstein',
-    type: 'Highway',
+    type: 'Hwy',
     city: 'Sebastopol',
     state: 'CA'
   },
   '1005 N Gravenstein Highway, Suite 500, Sebastopol, CA': {
-    number: '1005',
-    prefix: 'N',
+    type: 'Hwy',
     street: 'Gravenstein',
-    type: 'Highway',
-    sec_unit_type: 'Suite',
-    sec_unit_num: '500',
     city: 'Sebastopol',
-    state: 'CA'
+    state: 'CA',
+    prefix: 'N',
+    sec_unit_num: '500',
+    sec_unit_type: 'Suite',
+    number: '1005'
   },
   '1005 N Gravenstein Hwy Suite 500 Sebastopol, CA': {
     number: '1005',
-    prefix: 'N',
-    street: 'Gravenstein',
     type: 'Hwy',
-    sec_unit_type: 'Suite',
-    sec_unit_num: '500',
     city: 'Sebastopol',
-    state: 'CA'
+    state: 'CA',
+    sec_unit_type: 'Suite',
+    street: 'Gravenstein',
+    prefix: 'N',
+    sec_unit_num: '500'
   },
   '1005 N Gravenstein Highway, Sebastopol, CA, 95472': {
-    number: '1005',
-    prefix: 'N',
-    street: 'Gravenstein',
-    type: 'Highway',
-    city: 'Sebastopol',
     state: 'CA',
-    zip: '95472'
+    number: '1005',
+    zip: '95472',
+    prefix: 'N',
+    city: 'Sebastopol',
+    street: 'Gravenstein',
+    type: 'Hwy'
   },
   '1005 N Gravenstein Highway Sebastopol CA 95472': {
-    number: '1005',
-    prefix: 'N',
     street: 'Gravenstein',
-    type: 'Highway',
-    city: 'Sebastopol',
+    zip: '95472',
+    prefix: 'N',
     state: 'CA',
-    zip: '95472'
+    number: '1005',
+    city: 'Sebastopol',
+    type: 'Hwy'
   },
   '1005 Gravenstein Hwy N Sebastopol CA': {
-    number: '1005',
     street: 'Gravenstein',
-    type: 'Hwy',
-    suffix: 'N',
+    state: 'CA',
     city: 'Sebastopol',
-    state: 'CA'
+    suffix: 'N',
+    number: '1005',
+    type: 'Hwy'
   },
   '1005 Gravenstein Hwy N, Sebastopol CA': {
-    number: '1005',
-    street: 'Gravenstein',
     type: 'Hwy',
+    number: '1005',
     suffix: 'N',
     city: 'Sebastopol',
+    street: 'Gravenstein',
     state: 'CA'
   },
   '1005 Gravenstein Hwy, N Sebastopol CA': {
-    number: '1005',
     street: 'Gravenstein',
-    type: 'Hwy',
+    number: '1005',
+    state: 'CA',
     city: 'North Sebastopol',
-    state: 'CA'
+    type: 'Hwy'
   },
   '1005 Gravenstein Hwy, North Sebastopol CA': {
-    number: '1005',
-    street: 'Gravenstein',
     type: 'Hwy',
-    city: 'North Sebastopol',
-    state: 'CA'
+    street: 'Gravenstein',
+    state: 'CA',
+    number: '1005',
+    city: 'North Sebastopol'
   },
   '1005 Gravenstein Hwy Sebastopol CA': {
     number: '1005',
-    street: 'Gravenstein',
     type: 'Hwy',
     city: 'Sebastopol',
-    state: 'CA'
+    state: 'CA',
+    street: 'Gravenstein'
   },
   '115 Broadway San Francisco CA': {
-    number: '115',
     street: 'Broadway',
+    type: '',
     city: 'San Francisco',
-    state: 'CA'
+    state: 'CA',
+    number: '115'
   },
   '7800 Mill Station Rd, Sebastopol, CA 95472': {
-    number: '7800',
-    street: 'Mill Station',
-    type: 'Rd',
-    city: 'Sebastopol',
     state: 'CA',
-    zip: '95472'
+    type: 'Rd',
+    street: 'Mill Station',
+    zip: '95472',
+    city: 'Sebastopol',
+    number: '7800'
   },
   '7800 Mill Station Rd Sebastopol CA 95472': {
     number: '7800',
-    street: 'Mill Station',
-    type: 'Rd',
     city: 'Sebastopol',
+    zip: '95472',
     state: 'CA',
-    zip: '95472'
+    type: 'Rd',
+    street: 'Mill Station'
   },
   '1005 State Highway 116 Sebastopol CA 95472': {
-    number: '1005',
-    street: 'State Highway 116',
+    type: 'Hwy',
     city: 'Sebastopol',
+    zip: '95472',
     state: 'CA',
-    zip: '95472'
+    street: 'State Highway 116',
+    number: '1005'
   },
   '1600 Pennsylvania Ave. Washington DC': {
-    number: '1600',
+    state: 'DC',
     street: 'Pennsylvania',
     type: 'Ave',
-    city: 'Washington',
-    state: 'DC'
+    number: '1600',
+    city: 'Washington'
   },
   '1600 Pennsylvania Avenue Washington DC': {
     number: '1600',
     street: 'Pennsylvania',
-    type: 'Avenue',
-    city: 'Washington',
-    state: 'DC'
+    state: 'DC',
+    type: 'Ave',
+    city: 'Washington'
   },
   '48S 400E, Salt Lake City UT': {
-    number: '48',
     prefix: 'S',
     street: '400',
-    suffix: 'E',
     city: 'Salt Lake City',
-    state: 'UT'
+    number: '48',
+    state: 'UT',
+    suffix: 'E',
+    type: ''
   },
   '550 S 400 E #3206, Salt Lake City UT 84111': {
-    number: '550',
-    prefix: 'S',
-    street: '400',
     suffix: 'E',
-    sec_unit_type: '#',
+    type: '',
+    number: '550',
     sec_unit_num: '3206',
-    city: 'Salt Lake City',
+    prefix: 'S',
     state: 'UT',
-    zip: '84111'
+    sec_unit_type: '#',
+    city: 'Salt Lake City',
+    zip: '84111',
+    street: '400'
   },
   '6641 N 2200 W Apt D304 Park City, UT 84098': {
-    number: '6641',
-    prefix: 'N',
-    street: '2200',
-    suffix: 'W',
-    sec_unit_type: 'Apt',
-    sec_unit_num: 'D304',
     city: 'Park City',
+    sec_unit_num: 'D304',
+    prefix: 'N',
+    type: '',
+    number: '6641',
+    sec_unit_type: 'Apt',
     state: 'UT',
+    suffix: 'W',
+    street: '2200',
     zip: '84098'
   },
   '100 South St, Philadelphia, PA': {
-    number: '100',
     street: 'South',
-    type: 'St',
     city: 'Philadelphia',
-    state: 'PA'
+    state: 'PA',
+    type: 'St',
+    number: '100'
   },
   '100 S.E. Washington Ave, Minneapolis, MN': {
-    number: '100',
-    prefix: 'SE.',
-    street: 'Washington',
-    type: 'Ave',
     city: 'Minneapolis',
-    state: 'MN'
+    type: 'Ave',
+    state: 'MN',
+    street: 'Washington',
+    prefix: 'SE',
+    number: '100'
   },
   '3813 1/2 Some Road, Los Angeles, CA': {
     number: '3813',
     street: 'Some',
-    type: 'Road',
-    city: 'Los Angeles',
-    state: 'CA'
+    type: 'Rd',
+    state: 'CA',
+    city: 'Los Angeles'
   },
   'Mission & Valencia San Francisco CA': {
-    street1: 'Mission',
-    street2: 'Valencia',
-    city: 'San Francisco',
-    state: 'CA',
     type2: '',
-    type1: ''
+    street2: 'Valencia',
+    state: 'CA',
+    city: 'San Francisco',
+    type1: '',
+    street1: 'Mission'
   },
   'Mission & Valencia, San Francisco CA': {
-    street1: 'Mission',
-    street2: 'Valencia',
+    type1: '',
     city: 'San Francisco',
-    state: 'CA',
     type2: '',
-    type1: ''
+    street1: 'Mission',
+    state: 'CA',
+    street2: 'Valencia'
   },
   'Mission St and Valencia St San Francisco CA': {
-    street1: 'Mission',
     type1: 'St',
-    street2: 'Valencia',
-    type2: 'St',
-    city: 'San Francisco',
-    state: 'CA'
-  },
-  'Mission St & Valencia St San Francisco CA': {
-    street1: 'Mission',
-    type1: 'St',
-    street2: 'Valencia',
-    type2: 'St',
-    city: 'San Francisco',
-    state: 'CA'
-  },
-  'Mission and Valencia Sts San Francisco CA': {
-    street1: 'Mission',
-    street2: 'Valencia',
-    type2: 'St',
     city: 'San Francisco',
     state: 'CA',
+    street2: 'Valencia',
+    type2: 'St',
+    street1: 'Mission'
+  },
+  'Mission St & Valencia St San Francisco CA': {
+    street2: 'Valencia',
+    state: 'CA',
+    street1: 'Mission',
+    type2: 'St',
+    city: 'San Francisco',
     type1: 'St'
+  },
+  'Mission and Valencia Sts San Francisco CA': {
+    type2: 'St',
+    street1: 'Mission',
+    type1: 'St',
+    city: 'San Francisco',
+    street2: 'Valencia',
+    state: 'CA'
   },
   'Mission & Valencia Sts. San Francisco CA': {
     street1: 'Mission',
     street2: 'Valencia',
-    type2: 'St',
+    type1: 'St',
     city: 'San Francisco',
     state: 'CA',
-    type1: 'St'
+    type2: 'St'
   },
   'Mission & Valencia Streets San Francisco CA': {
     street1: 'Mission',
-    street2: 'Valencia',
-    type2: 'Street',
+    type2: 'St',
     city: 'San Francisco',
     state: 'CA',
-    type1: 'Street'
+    type1: 'St',
+    street2: 'Valencia'
   },
   'Mission Avenue and Valencia Street San Francisco CA': {
-    street1: 'Mission',
-    type1: 'Avenue',
-    street2: 'Valencia',
-    type2: 'Street',
+    type1: 'Ave',
+    state: 'CA',
     city: 'San Francisco',
-    state: 'CA'
+    street1: 'Mission',
+    type2: 'St',
+    street2: 'Valencia'
   },
   '1 First St, e San Jose CA': {
-    number: '1',
     street: 'First',
-    type: 'St',
+    number: '1',
     city: 'East San Jose',
-    state: 'CA'
+    state: 'CA',
+    type: 'St'
   },
   '123 Maple Rochester, New York': {
-    number: '123',
-    street: 'Maple',
     city: 'Rochester',
-    state: 'New York'
+    street: 'Maple',
+    number: '123',
+    state: 'NY',
+    type: ''
   },
   '233 S Wacker Dr 60606-6306': {
+    type: 'Dr',
     number: '233',
     prefix: 'S',
-    street: 'Wacker',
-    type: 'Dr',
     zip: '60606',
-    plus4: '6306'
+    street: 'Wacker'
   },
   '233 S Wacker Dr 606066306': {
-    number: '233',
-    prefix: 'S',
     street: 'Wacker',
-    type: 'Dr',
     zip: '60606',
-    plus4: '6306'
-  },
-   "233 S Wacker Dr 60606 6306": {
-     number: "233",
-     prefix: "S",
-     street: "Wacker",
-     type: "Dr",
-     zip: "60606",
-     plus4: "6306"
-   },
-   "S Wacker Dr 60606 6306": {
-     prefix: "S",
-     street: "Wacker",
-     type: "Dr",
-     zip: "60606",
-     plus4: "6306"
-   },
-  '233 S Wacker Dr lobby 60606': {
-    number: '233',
-    prefix: 'S',
-    street: 'Wacker',
     type: 'Dr',
+    number: '233',
+    prefix: 'S'
+  },
+  '233 S Wacker Dr 60606 6306': {
+    type: 'Dr',
+    prefix: 'S',
+    zip: '60606',
+    street: 'Wacker',
+    number: '233'
+  },
+  'S Wacker Dr 60606 6306': {
+    zip: '60606',
+    type: 'Dr',
+    street: 'Wacker',
+    prefix: 'S'
+  },
+  '233 S Wacker Dr lobby 60606': {
     sec_unit_type: 'lobby',
+    prefix: 'S',
+    type: 'Dr',
+    number: '233',
+    street: 'Wacker',
     zip: '60606'
   },
   '(233 S Wacker Dr lobby 60606)': {
-    number: '233',
-    prefix: 'S',
+    zip: '60606',
+    sec_unit_type: 'lobby',
     street: 'Wacker',
     type: 'Dr',
-    sec_unit_type: 'lobby',
-    zip: '60606'
+    number: '233',
+    prefix: 'S'
   },
   '#42 233 S Wacker Dr 60606': {
-    sec_unit_type: '#',
-    sec_unit_num: '42',
-    number: '233',
-    prefix: 'S',
-    street: 'Wacker',
     type: 'Dr',
-    zip: '60606'
+    prefix: 'S',
+    zip: '60606',
+    sec_unit_num: '42',
+    sec_unit_type: '#',
+    number: '233',
+    street: 'Wacker'
   },
   'lt42 99 Some Road, Some City LA': {
-    sec_unit_type: 'lt',
-    sec_unit_num: '42',
-    number: '99',
-    street: 'Some',
-    type: 'Road',
     city: 'Some City',
-    state: 'LA'
+    state: 'LA',
+    type: 'Rd',
+    sec_unit_type: 'lt',
+    street: 'Some',
+    number: '99',
+    sec_unit_num: '42'
   },
   '36401 County Road 43, Eaton, CO 80615': {
-    number: '36401',
+    type: 'Rd',
     street: 'County Road 43',
-    city: 'Eaton',
+    number: '36401',
+    zip: '80615',
     state: 'CO',
-    zip: '80615'
+    city: 'Eaton'
   },
   '1234 COUNTY HWY 60E, Town, CO 12345': {
-    number: '1234',
-    street: 'COUNTY HWY 60',
     suffix: 'E',
-    city: 'Town',
     state: 'CO',
-    zip: '12345'
+    type: '',
+    zip: '12345',
+    number: '1234',
+    city: 'Town',
+    street: 'COUNTY HWY 60'
   },
   '321 S. Washington': {
-    number: '321',
     prefix: 'S',
-    street: 'Washington'
+    street: 'Washington',
+    type: '',
+    number: '321'
   },
   '\'45 Quaker Ave, Ste 105\'': {
-    number: '45',
-    street: 'Quaker',
-    type: 'Ave',
     sec_unit_type: 'Ste',
+    street: 'Quaker',
+    number: '45',
+    type: 'Ave',
     sec_unit_num: '105'
   },
   '2672 Industrial Row Troy, MI 48084': {
+    zip: '48084',
+    city: 'Row Troy',
     number: '2672',
-    street: 'Industrial',
-    type: 'Row',
-    city: 'Troy',
     state: 'MI',
-    zip: '48084'
+    type: '',
+    street: 'Industrial'
   }
 };
 
-Object.keys(address).forEach(function(k) {
+Object.keys(address).forEach(function (k) {
   var parsed = parser.parseLocation(k);
   assert.deepEqual(address[k], parsed);
 });

--- a/test.js
+++ b/test.js
@@ -388,5 +388,4 @@ var address = {
 Object.keys(address).forEach(function (k) {
   var parsed = parser.parseLocation(k);
   assert.deepEqual(address[k], parsed);
-  console.log(JSON.stringify({[k]: parsed}))
 });


### PR DESCRIPTION
Geo::StreetAddress::US creates a [list of keys](https://metacpan.org/source/TIMB/Geo-StreetAddress-US-1.04/US.pm#L702-713) to check and normalize. In the normalize_address function it goes through those keys and [normalizes the values](https://metacpan.org/source/TIMB/Geo-StreetAddress-US-1.04/US.pm#L1054-1058). This port is currently missing that normalization. This PR adds that normalizer.

Because the normalizer changes the output of the function, I had to update the test.js file to reflect the changes. To ensure the new test cases matched what the PERL library would output, I created the values by calling the perl library directly for all the addresses. After I did this I noticed `plus4` was missing from the perl library. I manually altered the data that PERL created to add `plus4`.

With the new tests, the punctuation parser was failing because it converted "S.E." to "SE.". The output from the PERL library was "SE". This seems to be because the punctuation regex was different between this port and the PERL library. I updated the regex so they are both the same, and this test case was resolved.

Lastly, PERL does not support the street type 'Row'. The test case for Row was manually updated to work for this library, and not be what the PERL library outputs.