### PR TITLE
add missing Street_Type

### DIFF
--- a/address.js
+++ b/address.js
@@ -52,6 +52,7 @@
     bot         : "btm",
     bottm       : "btm",
     bottom      : "btm",
+    bl          : "blvd",       
     boul        : "blvd",
     boulevard   : "blvd",
     boulv       : "blvd",


### PR DESCRIPTION
I saw that sometimes I get  "bl" as a short of "blvd".   