### PR TITLE
allow slashes in addresses

### DIFF
--- a/address.js
+++ b/address.js
@@ -665,7 +665,7 @@
         return;
       var key = isFinite(k.split('_').pop())? k.split('_').slice(0,-1).join('_'): k ;
       if(parts[k])
-        parsed[key] = parts[k].trim().replace(/^\s+|\s+$|[^\w\s\-#&]/g, '');
+        parsed[key] = parts[k].trim().replace(/^\s+|\s+$|[^\w\s\-#&\/]/g, '');
     });
     each(Normalize_Map, function(map,key) {
       if(parsed[key] && map[parsed[key].toLowerCase()]) {


### PR DESCRIPTION
for instance [32 1/8 Rd.](https://www.google.com/maps/place/32+1%2F8+Rd,+Clifton,+CO+81520) in Clifton CO which is not to be confused with 32 Rd. (which is an 1/8 of a mile away) or 32 1/2 Rd (which is 3/8th of a mile away), which just to make things fun the address numbering is based on a grid so any address on 32 1/8 Rd or 32 1/2 Rd is basically guarenteed to be near the same address on 32 Rd (so those fractions are load bearing) 